### PR TITLE
Add google api core dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ wordcloud
 matplotlib
 seaborn
 google-genai
+google-api-core


### PR DESCRIPTION
## Summary
- add the google-api-core package to the project's Python requirements so the app can import google.api_core exceptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ddc8f0b8832e9c1054518fba8a04
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added google-api-core to requirements to fix ModuleNotFoundError when importing google.api_core.exceptions. This enables proper Google API error handling at runtime.

<!-- End of auto-generated description by cubic. -->

